### PR TITLE
feat(api-gateway)!: implement VPC Link integration with internal NLB

### DIFF
--- a/2-eks/variables.tf
+++ b/2-eks/variables.tf
@@ -84,7 +84,7 @@ variable "node_group_instance_types" {
 
 variable "node_group_desired_size" {
   type        = number
-  default     = 4
+  default     = 5
   description = "Desired number of nodes in node group"
 }
 
@@ -96,6 +96,6 @@ variable "node_group_min_size" {
 
 variable "node_group_max_size" {
   type        = number
-  default     = 4
+  default     = 6
   description = "Maximum number of nodes in node group"
 }

--- a/4-api-gateway/variables.tf
+++ b/4-api-gateway/variables.tf
@@ -69,3 +69,21 @@ variable "cors_max_age" {
   default     = 300
   description = "Maximum age for CORS preflight requests in seconds"
 }
+
+variable "nlb_name" {
+  type        = string
+  default     = "ad51ed2ea764549dc8a78495dfb5e978"
+  description = "Name of the internal NLB created by the Kubernetes Service"
+}
+
+variable "backend_listener_port" {
+  type        = number
+  default     = 80
+  description = "Listener port on the NLB to route traffic to the backend"
+}
+
+variable "route_key" {
+  type        = string
+  default     = "ANY /{proxy+}"
+  description = "API Gateway route key to bind to the backend integration"
+}

--- a/helm/fast-food/templates/service.yaml
+++ b/helm/fast-food/templates/service.yaml
@@ -3,6 +3,11 @@ kind: Service
 metadata:
   name: {{ include "fast-food.fullname" . }}
   namespace: {{ .Values.namespace.name }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-name: "fast-food-nlb"
   labels:
     {{- include "fast-food.labels" . | nindent 4 }}
 spec:

--- a/helm/fast-food/values.yaml
+++ b/helm/fast-food/values.yaml
@@ -1,7 +1,11 @@
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
 app:
   name: fast-food-api
   image:
-    repository: danieltezolin/fast-food-api
+    repository: tezolind/fast-food-api
     tag: "latest"
     pullPolicy: IfNotPresent
   
@@ -45,9 +49,9 @@ app:
 
 env:
   # Database
-  DB_HOST: "your-rds-endpoint.rds.amazonaws.com"
+  DB_HOST: "soatfastfood.cu30cqsew6wy.us-east-1.rds.amazonaws.com"
   DB_PORT: "3306"
-  DB_NAME: "soatfastfood"
+  DB_NAME: "fast_food_db"
   DB_USER: "app_user"
   
   # Application
@@ -56,7 +60,7 @@ env:
   ENVIRONMENT: "production"
 
 secrets:
-  DB_PASSWORD: "eW91cl9iYXNlNjRfZW5jb2RlZF9wYXNzd29yZA=="
+  DB_PASSWORD: "RlR0V1Facko2Y3Jmdk1kUE5xbkw="
   
   ACCESSTOKEN: "eW91cl9tZXJjYWRvcGFnb190b2tlbl9oZXJl"
 


### PR DESCRIPTION
- Enable VPC Link with security group for private backend connectivity
- Add integration to internal NLB created by Kubernetes Service
- Configure route ANY /{proxy+} with path forwarding to backend
- Update Helm chart to provision internal NLB with proper annotations
- Configure RDS endpoint and credentials in values.yaml
- Increase EKS node group capacity (desired: 5, max: 6)
- Rewrite comprehensive README with architecture diagrams and troubleshooting

BREAKING CHANGE: API Gateway now requires internal NLB to be provisioned. The nlb_name variable must be set to match the NLB created by the Kubernetes Service.